### PR TITLE
Add support for variables defined in directories

### DIFF
--- a/nornir_ansible/plugins/inventory/ansible.py
+++ b/nornir_ansible/plugins/inventory/ansible.py
@@ -4,7 +4,7 @@ import logging
 import os
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, MutableMapping, Optional, Tuple, Type, Union, cast
+from typing import Any, DefaultDict, Dict, MutableMapping, Optional, Tuple, Type, Union, cast, List
 
 import ruamel.yaml
 from mypy_extensions import TypedDict
@@ -23,7 +23,8 @@ from ruamel.yaml.composer import ComposerError
 from ruamel.yaml.scanner import ScannerError
 
 VARS_FILENAME_EXTENSIONS = ["", ".ini", ".yml", ".yaml"]
-RESERVED_FIELDS = ("hostname", "port", "username", "password", "platform", "connection_options")
+RESERVED_FIELDS = ("hostname", "port", "username",
+                   "password", "platform", "connection_options")
 YAML = ruamel.yaml.YAML(typ="safe")
 LOG = logging.getLogger(__name__)
 
@@ -81,14 +82,37 @@ class AnsibleParser:
             dest_group["groups"].append(parent)
 
         group_data = data.get("vars", {})
-        vars_file_data = self.read_vars_file(group_file, self.path, False) or {}
+
+        vars_file_data = {}
+        if self._vars_file_exists(f"{self.path}/group_vars/{group_file}"):
+            vars_file_data = self.read_vars_file(
+                element=group_file,
+                path=self.path,
+                is_host=False,
+                is_dir=False
+            )
+        elif Path(f"{self.path}/group_vars/{group_file}").is_dir:
+            for file in self._get_all_files(f"{self.path}/group_vars/{group_file}"):
+                t_vars_file_data = self.read_vars_file(
+                    element=group_file,
+                    path=file,
+                    is_host=False,
+                    is_dir=True,
+                )
+                if isinstance(t_vars_file_data, dict):
+                    vars_file_data = {
+                        **t_vars_file_data,
+                        **vars_file_data
+                    }
+    
         self.normalize_data(dest_group, group_data, vars_file_data)
         self.map_nornir_vars(dest_group)
 
         self.parse_hosts(data.get("hosts", {}), parent=group)
 
         for children, children_data in data.get("children", {}).items():
-            self.parse_group(children, cast(AnsibleGroupDataDict, children_data), parent=group)
+            self.parse_group(children, cast(
+                AnsibleGroupDataDict, children_data), parent=group)
 
     def parse(self) -> None:
         """Parse inventory entrypoint"""
@@ -111,9 +135,66 @@ class AnsibleParser:
             if parent and parent != "defaults":
                 self.hosts[host]["groups"].append(parent)
 
-            vars_file_data = self.read_vars_file(host, self.path, True)
+            vars_file_data = {}
+            if self._vars_file_exists(f"{self.path}/host_vars/{host}"):
+                vars_file_data = self.read_vars_file(
+                    element=host,
+                    path=self.path,
+                    is_host=True,
+                    is_dir=False
+                )
+
+            elif Path(f"{self.path}/host_vars/{host}").is_dir:
+                vars_file_data = {}
+                for file in self._get_all_files(f"{self.path}/host_vars/{host}"):
+                    t_vars_file_data = self.read_vars_file(
+                        element=host,
+                        path=file,
+                        is_host=True,
+                        is_dir=True,
+                    )
+                    if isinstance(t_vars_file_data, dict):
+                        vars_file_data = {
+                            **t_vars_file_data,
+                            **vars_file_data
+                    }                
+
             self.normalize_data(self.hosts[host], data, vars_file_data)
             self.map_nornir_vars(self.hosts[host])
+
+    def _get_all_files(self, path: str) -> List[str]:
+        """Get all files with VARS_FILENAME_EXTENSIONS, contains in path/ and subdirectories
+
+        Args:
+            path (str): [Path to directoy]
+
+        Returns:
+            List[str]: [List of files that are in this directoy and subdirectories]
+        """
+        files_lst = list()
+        for root, subdirs, files in os.walk(f"{path}"):
+            for file in files:
+                if (
+                    file[file.rfind("."):] in VARS_FILENAME_EXTENSIONS
+                    and Path(f"{root}/{file}").is_file()
+                ):
+                    files_lst.append(f"{root}/{file}")
+        
+        return files_lst
+
+    def _vars_file_exists(self, path: str) -> bool:
+        """With VARS_FILENAME_EXTENSIONS, check if the file given in parameter exists.
+
+        Args:
+            path (str): [Path to file (without extension)]
+
+        Returns:
+            bool: [True if a file exists with of of the extension.]
+        """
+        for ext in VARS_FILENAME_EXTENSIONS:
+            if os.path.isfile(f"{path}{ext}"):
+                return True
+        return False
 
     def normalize_data(self, host: Hosts, data: Dict[str, Any], vars_data: Dict[str, Any]) -> None:
         """
@@ -159,7 +240,7 @@ class AnsibleParser:
             group["groups"].sort()
 
     @staticmethod
-    def read_vars_file(element: str, path: str, is_host: bool = True) -> VarsDict:
+    def read_vars_file(element: str, path: str, is_host: bool = True, is_dir: bool = False) -> VarsDict:
         """
         Read vars file data, return `VarsDict`
 
@@ -167,17 +248,28 @@ class AnsibleParser:
             element: inventory element being parsed, i.e. name of host or group being parsed
             path: parent directory of inventory file
             is_host: bool indicating if reading a host vars file or if false a group vars file
+            is_dir: bool indicating if variables are defined in a directory
 
         """
         sub_dir = "host_vars" if is_host else "group_vars"
         vars_dir = Path(path) / sub_dir
-        if vars_dir.is_dir():
+        
+        if is_dir:
+            with open(path) as f:
+                for ext in VARS_FILENAME_EXTENSIONS:
+                    if Path(f"{path}{ext}").is_file():
+                        LOG.debug("AnsibleInventory: reading var file %r", path)
+                        return cast(Dict[str, Any], YAML.load(f))
+
+        elif vars_dir.is_dir():
             vars_file_base = vars_dir / element
             for extension in VARS_FILENAME_EXTENSIONS:
-                vars_file = vars_file_base.with_suffix(vars_file_base.suffix + extension)
+                vars_file = vars_file_base.with_suffix(
+                    vars_file_base.suffix + extension)
                 if vars_file.is_file():
                     with open(vars_file) as f:
-                        LOG.debug("AnsibleInventory: reading var file %r", vars_file)
+                        LOG.debug(
+                            "AnsibleInventory: reading var file %r", vars_file)
                         return cast(Dict[str, Any], YAML.load(f))
             LOG.debug(
                 "AnsibleInventory: no vars file was found with the path %r "
@@ -289,7 +381,8 @@ class INIParser(AnsibleParser):
         groups: DefaultDict[str, Dict[str, Any]] = defaultdict(dict)
         # Dict[str, AnsibleGroupDataDict] does not work because of
         # https://github.com/python/mypy/issues/5359
-        result: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]] = {"all": {"children": groups}}
+        result: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]] = {
+            "all": {"children": groups}}
 
         for section_name, section in data.items():
 
@@ -311,7 +404,8 @@ class INIParser(AnsibleParser):
 
     def load_hosts_file(self) -> None:
         """Parse host specific inventory files"""
-        original_data = cp.ConfigParser(interpolation=None, allow_no_value=True, delimiters=" =")
+        original_data = cp.ConfigParser(
+            interpolation=None, allow_no_value=True, delimiters=" =")
         original_data.read(self.hostsfile)
         self.original_data = self.normalize(original_data)
 
@@ -337,7 +431,8 @@ def parse(hostsfile: str) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any
         try:
             parser = YAMLParser(hostsfile)
         except (ScannerError, ComposerError):
-            LOG.error("AnsibleInventory: file %r is not INI or YAML file", hostsfile)
+            LOG.error(
+                "AnsibleInventory: file %r is not INI or YAML file", hostsfile)
             raise NornirNoValidInventoryError(
                 f"AnsibleInventory: no valid inventory source(s) to parse. Tried: {hostsfile}"
             )
@@ -381,7 +476,8 @@ def _get_defaults(data: Dict[str, Any]) -> Defaults:
         password=data.get("password"),
         platform=data.get("platform"),
         data=data.get("data"),
-        connection_options=_get_connection_options(data.get("connection_options", {})),
+        connection_options=_get_connection_options(
+            data.get("connection_options", {})),
     )
 
 
@@ -405,7 +501,8 @@ def _get_inventory_element(
         data=data.get("data"),
         groups=data.get("groups"),
         defaults=defaults,
-        connection_options=_get_connection_options(data.get("connection_options", {})),
+        connection_options=_get_connection_options(
+            data.get("connection_options", {})),
     )
 
 

--- a/tests/ansible/yaml4/expected/defaults.yaml
+++ b/tests/ansible/yaml4/expected/defaults.yaml
@@ -1,0 +1,8 @@
+connection_options: {}
+data:
+  simulate_all_data: simulate_all_data
+hostname: null
+password: null
+platform: null
+port: null
+username: null

--- a/tests/ansible/yaml4/expected/groups.yaml
+++ b/tests/ansible/yaml4/expected/groups.yaml
@@ -1,0 +1,30 @@
+eric_eccli:
+  connection_options: {}
+  data:
+    ntp_mode:
+      servers:
+        - server_choice: 1.1.1.1
+          version: 3
+          source: management
+        - server_choice: 2.2.2.2
+          version: 3
+          source: management
+        - server_choice: 3.3.3.3
+          version: 3
+          source: management
+  groups: []
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null
+iosxr:
+  connection_options: {}
+  data:
+    simulate_iosxr_data: simulate_iosxr_data 
+  groups: []
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null

--- a/tests/ansible/yaml4/expected/hosts.yaml
+++ b/tests/ansible/yaml4/expected/hosts.yaml
@@ -1,0 +1,26 @@
+lab_a_router_02:
+  connection_options: {}
+  data:
+    interfaces:
+      loopback1:
+        ip: 1.2.3.4/32
+  groups:
+  - eric_eccli
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null
+lab_a_router_01:
+  connection_options: {}
+  data:
+    interfaces:
+      loopback1:
+        ip: 4.3.2.1/32
+  groups:
+    - iosxr
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null

--- a/tests/ansible/yaml4/source/group_vars/all/vars.yml
+++ b/tests/ansible/yaml4/source/group_vars/all/vars.yml
@@ -1,0 +1,2 @@
+---
+simulate_all_data: simulate_all_data

--- a/tests/ansible/yaml4/source/group_vars/eric_eccli/ntp/ntp.yml
+++ b/tests/ansible/yaml4/source/group_vars/eric_eccli/ntp/ntp.yml
@@ -1,0 +1,12 @@
+---
+ntp_mode:
+  servers:
+    - server_choice: 1.1.1.1
+      version: 3
+      source: management
+    - server_choice: 2.2.2.2
+      version: 3
+      source: management
+    - server_choice: 3.3.3.3
+      version: 3
+      source: management

--- a/tests/ansible/yaml4/source/group_vars/iosxr.yml
+++ b/tests/ansible/yaml4/source/group_vars/iosxr.yml
@@ -1,0 +1,2 @@
+---
+simulate_iosxr_data: simulate_iosxr_data 

--- a/tests/ansible/yaml4/source/host_vars/lab_a_router_01.yml
+++ b/tests/ansible/yaml4/source/host_vars/lab_a_router_01.yml
@@ -1,0 +1,4 @@
+---
+interfaces:
+  loopback1:
+    ip: 4.3.2.1/32

--- a/tests/ansible/yaml4/source/host_vars/lab_a_router_02/vars.yml
+++ b/tests/ansible/yaml4/source/host_vars/lab_a_router_02/vars.yml
@@ -1,0 +1,4 @@
+---
+interfaces:
+  loopback1:
+    ip: 1.2.3.4/32

--- a/tests/ansible/yaml4/source/hosts
+++ b/tests/ansible/yaml4/source/hosts
@@ -1,0 +1,8 @@
+all:
+  children:
+    iosxr:
+      hosts:
+        lab_a_router_01: {}
+    eric_eccli:
+      hosts:
+        lab_a_router_02: {}

--- a/tests/test_ansible.py
+++ b/tests/test_ansible.py
@@ -22,7 +22,7 @@ def read(hosts_file, groups_file, defaults_file):
 
 
 class Test(object):
-    @pytest.mark.parametrize("case", ["ini", "yaml", "yaml2", "yaml3"])
+    @pytest.mark.parametrize("case", ["ini", "yaml", "yaml2", "yaml3", "yaml4"])
     def test_inventory(self, case):
         base_path = os.path.join(BASE_PATH, case)
         expected_hosts_file = os.path.join(base_path, "expected", "hosts.yaml")


### PR DESCRIPTION
As example:

```
inventories/lab//host_vars
├── lab_a_router_01
│   ├── interfaces.yml
│   ├── vars.yml
│   └── vault.yml
└── lab_a_router_02
    ├── s_links.yml
    ├── s_vars.yml
    ├── vars.yml
    ├── y_bfd.yml
    ├── y_interfaces.
```