### PR TITLE
Hostname will use domain name when no `ansible_host` is defined.

### DIFF
--- a/tests/ansible/ini/expected/hosts.yaml
+++ b/tests/ansible/ini/expected/hosts.yaml
@@ -2,8 +2,8 @@ bar.example.com:
   connection_options: {}
   data: {}
   groups:
-  - webservers
-  hostname: null
+    - webservers
+  hostname: bar.example.com
   password: null
   platform: null
   port: null
@@ -12,9 +12,9 @@ foo.example.com:
   connection_options: {}
   data: {}
   groups:
-  - frontend
-  - webservers
-  hostname: null
+    - frontend
+    - webservers
+  hostname: foo.example.com
   password: null
   platform: null
   port: null
@@ -24,8 +24,8 @@ one.example.com:
   data:
     my_var: from_one.example.com
   groups:
-  - dbservers
-  hostname: null
+    - dbservers
+  hostname: one.example.com
   password: null
   platform: null
   port: null
@@ -34,7 +34,7 @@ three.example.com:
   connection_options: {}
   data: {}
   groups:
-  - dbservers
+    - dbservers
   hostname: 192.0.2.50
   password: null
   platform: null
@@ -46,7 +46,7 @@ two.example.com:
     my_var: from_hostfile
     whatever: asdasd
   groups:
-  - dbservers
+    - dbservers
   hostname: null
   password: null
   platform: null


### PR DESCRIPTION
At the moment the test is failing because hostname is defined as `null` in the expected result.
The expected result should contain the domain name instead as `ansible_host` is not defined.
