### PR TITLE
Allow the use of ip addresses as hostname

### DIFF
--- a/nornir_ansible/plugins/inventory/ansible.py
+++ b/nornir_ansible/plugins/inventory/ansible.py
@@ -333,12 +333,12 @@ class INIParser(AnsibleParser):
         """
         result: VarsDict = {}
 
-        if not content:
-            return result
-
-        for option in content.split():
-            key, value = option.split("=")
-            result[key] = INIParser.normalize_value(value)
+        if "=" in content:
+            for option in content.split():
+                key, value = option.split("=")
+                result[key] = INIParser.normalize_value(value)
+        else:
+            result["ansible_host"] = INIParser.normalize_value(content)
         return result
 
     @staticmethod
@@ -385,9 +385,13 @@ class INIParser(AnsibleParser):
                 else:
                     groups[group_name][meta] = subsection
             else:
-                groups[section_name]["hosts"] = {
-                    host: self.normalize_content(host_vars) for host, host_vars in section.items()
-                }
+                groups[section_name]["hosts"] = dict()
+                for host, host_vars in section.items():
+                    if host_vars == None:
+                        groups[section_name]["hosts"][host] = self.normalize_content(host)
+                    else:
+                        groups[section_name]["hosts"][host] = self.normalize_content(host_vars)
+
         return cast(AnsibleGroupsDict, result)
 
     def load_hosts_file(self) -> None:

--- a/tests/ansible/ini/expected/groups.yaml
+++ b/tests/ansible/ini/expected/groups.yaml
@@ -4,7 +4,7 @@ dbservers:
     my_var: from_dbservers
     my_yet_another_var: from_dbservers
   groups:
-  - servers
+    - servers
   hostname: null
   password: null
   platform: null
@@ -36,7 +36,16 @@ webservers:
   connection_options: {}
   data: {}
   groups:
-  - servers
+    - servers
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null
+backend:
+  connection_options: {}
+  data: {}
+  groups: []
   hostname: null
   password: null
   platform: null

--- a/tests/ansible/ini/expected/hosts.yaml
+++ b/tests/ansible/ini/expected/hosts.yaml
@@ -52,3 +52,23 @@ two.example.com:
   platform: null
   port: null
   username: null
+172.16.1.1:
+  connection_options: {}
+  data: {}
+  groups:
+    - backend
+  hostname: 172.16.1.1
+  password: null
+  platform: null
+  port: null
+  username: null
+172.16.1.2:
+  connection_options: {}
+  data: {}
+  groups:
+    - backend
+  hostname: 172.16.1.2
+  password: null
+  platform: null
+  port: null
+  username: null

--- a/tests/ansible/ini/expected/hosts.yaml
+++ b/tests/ansible/ini/expected/hosts.yaml
@@ -2,8 +2,8 @@ bar.example.com:
   connection_options: {}
   data: {}
   groups:
-  - webservers
-  hostname: null
+    - webservers
+  hostname: bar.example.com
   password: null
   platform: null
   port: null
@@ -12,9 +12,9 @@ foo.example.com:
   connection_options: {}
   data: {}
   groups:
-  - frontend
-  - webservers
-  hostname: null
+    - frontend
+    - webservers
+  hostname: foo.example.com
   password: null
   platform: null
   port: null
@@ -24,8 +24,8 @@ one.example.com:
   data:
     my_var: from_one.example.com
   groups:
-  - dbservers
-  hostname: null
+    - dbservers
+  hostname: one.example.com
   password: null
   platform: null
   port: null
@@ -34,7 +34,7 @@ three.example.com:
   connection_options: {}
   data: {}
   groups:
-  - dbservers
+    - dbservers
   hostname: 192.0.2.50
   password: null
   platform: null
@@ -46,7 +46,7 @@ two.example.com:
     my_var: from_hostfile
     whatever: asdasd
   groups:
-  - dbservers
+    - dbservers
   hostname: null
   password: null
   platform: null

--- a/tests/ansible/ini/source/hosts
+++ b/tests/ansible/ini/source/hosts
@@ -10,6 +10,10 @@ three.example.com ansible_port=5555 ansible_host=192.0.2.50
 [frontend]
 foo.example.com
 
+[backend]
+172.16.1.1
+172.16.1.2
+
 [servers:children]
 webservers
 dbservers


### PR DESCRIPTION
This PR implements https://github.com/carlmontanari/nornir_ansible/issues/47, 
we can now use ip addresses without having to define `ansible_host`.
