### PR TITLE
Remove Python 3.6 and 3.7 support, removing mypy_extensions dependency

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 8
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: ["3.7", "3.8", "3.9", "3.10"]
+        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: set up python ${{ matrix.version }}

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 8
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: ["3.7", "3.8", "3.9", "3.10"]
+        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/nornir_ansible/plugins/inventory/ansible.py
+++ b/nornir_ansible/plugins/inventory/ansible.py
@@ -4,10 +4,21 @@ import logging
 from collections import defaultdict
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, List, MutableMapping, Optional, Tuple, Type, Union, cast
+from typing import (
+    Any,
+    DefaultDict,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Type,
+    TypedDict,
+    Union,
+    cast,
+)
 
 import ruamel.yaml
-from mypy_extensions import TypedDict
 from nornir.core.exceptions import NornirNoValidInventoryError
 from nornir.core.inventory import (
     ConnectionOptions,

--- a/setup.py
+++ b/setup.py
@@ -18,20 +18,17 @@ setuptools.setup(
     url="https://github.com/carlmontanari/nornir_ansible",
     packages=setuptools.find_packages(),
     install_requires=[
-        "mypy_extensions>=0.4.1,<2.0.0",
         "ruamel.yaml>=0.16.10,<1.0.0",
-        "nornir>=3.0.0a4,<4.0.0",
+        "nornir>=3.4.0,<4.0.0",
     ],
     extras_require={},
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     entry_points="""
     [nornir.plugins.inventory]
     AnsibleInventory=nornir_ansible.plugins.inventory:AnsibleInventory


### PR DESCRIPTION
The newest `nornir-ansible` can not be installed with the newest `nornir` versions because of the `mypy-extensions` dependencies. Nornir dropped Python 3.6 and 3.7 support, and with Python 3.8, `mypy-extensions` would not be needed anymore as `TypedDict` is part of the `typing` now..

```bash
(nornir_ansible) urs@DESKTOP-BM35OBL:~$ pip install nornir==3.4.1 nornir-ansible==2022.7.30
Collecting nornir==3.4.1
  Downloading nornir-3.4.1-py3-none-any.whl.metadata (5.5 kB)
Collecting nornir-ansible==2022.7.30
  Downloading nornir_ansible-2022.7.30-py3-none-any.whl (12 kB)
Collecting importlib-metadata<5,>=4 (from nornir==3.4.1)
  Downloading importlib_metadata-4.13.0-py3-none-any.whl (23 kB)
Collecting mypy_extensions<2.0.0,>=1.0.0 (from nornir==3.4.1)
  Downloading mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
Collecting ruamel.yaml>=0.17 (from nornir==3.4.1)
  Downloading ruamel.yaml-0.18.5-py3-none-any.whl.metadata (23 kB)
INFO: pip is looking at multiple versions of nornir-ansible to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install nornir-ansible==2022.7.30 and nornir==3.4.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    nornir 3.4.1 depends on mypy_extensions<2.0.0 and >=1.0.0
    nornir-ansible 2022.7.30 depends on mypy-extensions<1.0.0 and >=0.4.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

If you agree to drop Python 3.6 and 3.7, it would be nice to have a new release. I am happy to update the PR or find a solution to still support 3.6 and 3.7 by maybe updating `mypy-extensions` if you prefer.