### PR TITLE
Fix github action error

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -11,9 +11,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: set up python ${{ matrix.version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.version }}
       - name: setup test env
@@ -22,4 +22,4 @@ jobs:
           python -m pip install setuptools
           python -m pip install tox
       - name: run tox
-        run: python -m tox --skip-missing-interpreters=true
+        run: python -m tox -e py --skip-missing-interpreters=true

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py38,py39,py310,py311,py312
 
 [testenv]
-deps = -rrequirements-dev.txt
+deps = 
+    setuptools<81
+    -r requirements-dev.txt
 commands = python -m pytest tests/ .
 
 [testenv:py310]
-deps = -rrequirements-dev.txt
 commands =
     python -m pytest \
         --cov=nornir_ansible \


### PR DESCRIPTION
Fix github action errors.

Fixes #175 

updates to `tox.ini`
pinning `setuptools<81`. in deps
update envlist to match github workflow matrix


update `.github/workflows/commit.yaml` to use `-e py` in tox command to stop the skip messages.
update the workflow actions to latest.

Longer term, may be better to use something else over pylama.
